### PR TITLE
Implement "last tulul" to tell last active user

### DIFF
--- a/command_list
+++ b/command_list
@@ -31,3 +31,4 @@ top_contact - cukup jelas
 top_location - cukup jelas
 top_hour - jam paling aktif
 top_day - hari paling aktif
+last_tulul - terakhir menjadi tulul

--- a/lib/tulul_stats_bot/tulul_stats/group.rb
+++ b/lib/tulul_stats_bot/tulul_stats/group.rb
@@ -84,7 +84,8 @@ module TululStats
         rank = 0
         self.users.reject{ |b| b.last_tulul_at.nil? }.sort_by{ |b| b.last_tulul_at }.reverse.map do |cur|
           rank += 1
-          "#{rank}. #{cur.full_name}: #{cur.last_tulul_at}"
+          last_tulul_at = cur.last_tulul_at.utc.strftime("%y-%m-%d %H:%M UTC")
+          "#{rank}. #{cur.full_name}: #{last_tulul_at}"
         end.join("\n")
       else
         res =

--- a/lib/tulul_stats_bot/tulul_stats/group.rb
+++ b/lib/tulul_stats_bot/tulul_stats/group.rb
@@ -80,6 +80,12 @@ module TululStats
 
         ret += '</pre>'
         ret
+      elsif field.downcase == 'last_tulul'
+        rank = 0
+        self.users.reject{|b| b.last_tulul_at.nil?}.sort_by{|b| b.last_tulul_at}.inject('') do |prev, cur|
+          rank += 1
+          "#{prev}#{rank}. #{cur.full_name}: #{cur.last_tulul_at}\n"
+        end
       else
         res =
           if TululStats::Entity::ENTITY_QUERY.include?(field)

--- a/lib/tulul_stats_bot/tulul_stats/group.rb
+++ b/lib/tulul_stats_bot/tulul_stats/group.rb
@@ -82,10 +82,10 @@ module TululStats
         ret
       elsif field.downcase == 'last_tulul'
         rank = 0
-        self.users.reject{|b| b.last_tulul_at.nil?}.sort_by{|b| b.last_tulul_at}.inject('') do |prev, cur|
+        self.users.reject{ |b| b.last_tulul_at.nil? }.sort_by{ |b| b.last_tulul_at }.reverse.map do |cur|
           rank += 1
-          "#{prev}#{rank}. #{cur.full_name}: #{cur.last_tulul_at}\n"
-        end
+          "#{rank}. #{cur.full_name}: #{cur.last_tulul_at}"
+        end.join("\n")
       else
         res =
           if TululStats::Entity::ENTITY_QUERY.include?(field)

--- a/lib/tulul_stats_bot/tulul_stats/user.rb
+++ b/lib/tulul_stats_bot/tulul_stats/user.rb
@@ -26,6 +26,7 @@ module TululStats
     field :del_photo,         type: Integer, default: 0
     field :left_group,        type: Integer, default: 0
     field :join_group,        type: Integer, default: 0
+    field :last_tulul_at,     type: DateTime
 
     field :text,              type: Integer, default: 0
     field :audio,             type: Integer, default: 0

--- a/lib/tulul_stats_bot/tulul_stats_bot.rb
+++ b/lib/tulul_stats_bot/tulul_stats_bot.rb
@@ -70,6 +70,7 @@ class TululStatsBot
             user.inc_contact if message.contact
             user.inc_location if message.location
             user.last_tulul_at = DateTime.now
+            user.save
 
             message.entities.each do |entity|
               user.inc_mentioning if entity.type == 'mention'

--- a/lib/tulul_stats_bot/tulul_stats_bot.rb
+++ b/lib/tulul_stats_bot/tulul_stats_bot.rb
@@ -69,8 +69,7 @@ class TululStatsBot
             user.inc_voice if message.voice
             user.inc_contact if message.contact
             user.inc_location if message.location
-            user.last_tulul_at = DateTime.now
-            user.save
+            user.update_attribute(:last_tulul_at, DateTime.now)
 
             message.entities.each do |entity|
               user.inc_mentioning if entity.type == 'mention'

--- a/lib/tulul_stats_bot/tulul_stats_bot.rb
+++ b/lib/tulul_stats_bot/tulul_stats_bot.rb
@@ -11,7 +11,11 @@ class TululStatsBot
 
           query = /\/top_(.+)/.match(message.text).captures[0] rescue nil
           query = query.split('@')[0] rescue nil
-          if query && (TululStats::User.fields.keys.reject{ |field| TululStats::User::EXCEPTION.include?(field) } + TululStats::Entity::ENTITY_QUERY + TululStats::IsTime::TIME_QUERY).include?(query)
+          if /^\/last_tulul([@].+)?/.match(message.text.strip)
+            res = group.top('last_tulul')
+            res = 'Belum cukup data' if res.gsub("\n", '').strip.empty?
+            @@bot.api.send_message(chat_id: message.chat.id, text: res, reply_to_message_id: message.message_id, parse_mode: 'HTML') rescue retry
+          elsif query && (TululStats::User.fields.keys.reject{ |field| TululStats::User::EXCEPTION.include?(field) } + TululStats::Entity::ENTITY_QUERY + TululStats::IsTime::TIME_QUERY).include?(query)
             res = group.top(query)
             res = 'Belum cukup data' if res.gsub("\n", '').empty?
             @@bot.api.send_message(chat_id: message.chat.id, text: res, reply_to_message_id: message.message_id, parse_mode: 'HTML') rescue retry
@@ -65,6 +69,7 @@ class TululStatsBot
             user.inc_voice if message.voice
             user.inc_contact if message.contact
             user.inc_location if message.location
+            user.last_tulul_at = DateTime.now
 
             message.entities.each do |entity|
               user.inc_mentioning if entity.type == 'mention'


### PR DESCRIPTION
Is it a nice idea to have "last tulul activity"? I know currently we only implement "top_x" queries, but since this is related to "stats", i think this fits our product, too.

I know this code is not good yet. We should use "last_x" generic format instead of hardcoding it. I open to any suggestion.

Thanks!
